### PR TITLE
Fix the rampant "constant" color highlights

### DIFF
--- a/languages/jai/brackets.scm
+++ b/languages/jai/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/languages/jai/highlights.scm
+++ b/languages/jai/highlights.scm
@@ -148,9 +148,9 @@ keyword: (identifier) @keyword
 
 ; Constants
 
-((identifier) @constant
-  (#lua-match? @constant "^_*[A-Z][A-Z0-9_]*$")
-  (#not-has-parent? @constant type parameter))
+; ((identifier) @constant
+;   (#lua-match? @constant "^_*[A-Z][A-Z0-9_]*$")
+;   (#not-has-parent? @constant type parameter))
 
 (member_expression . "." (identifier) @constant)
 

--- a/src/jai.rs
+++ b/src/jai.rs
@@ -48,9 +48,10 @@ impl zed::Extension for JaiExtension {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<zed::Command> {
-        let ols_binary_path = self.language_server_binary_path(language_server_id, worktree)?;
+        let jails_binary_path = self.language_server_binary_path(language_server_id, worktree)?;
         Ok(zed::Command {
-            command: ols_binary_path,
+            command: jails_binary_path,
+            // args: vec!["-verbose".to_string()],
             args: Default::default(),
             env: Default::default(),
         })


### PR DESCRIPTION
Ahoy!

This should correct the weirdly "everything is a constant" syntax highlighting issue. This improves the outline view slightly too apparently.

I tried to figure out indents but no luck yet. And for some reason enum fields are all sequentially nested by the outline query and can't be navigated to using the outliner.

You might also be interested in building jails from my fork in order to have it correctly load jails.json (https://github.com/photex/Jails). This should fix a lot of the other paper cuts as it can determine project structure using jails.json.