### PR TITLE
Add basic auto-indentation queries

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "jai"
 name = "Jai"
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Aman Tuladhar", "Chip Collier"]
 description = "Jai language support"

--- a/languages/jai/indents.scm
+++ b/languages/jai/indents.scm
@@ -1,0 +1,6 @@
+(block "{" @start "}" @end) @indent
+(struct_or_union_block "{" @start "}" @end) @indent
+(enum_declaration "{" @start "}" @end) @indent
+
+(_ "(" @start ")" @end) @indent
+(_ "[" @start "]" @end) @indent


### PR DESCRIPTION
It kept bugging me a bit that indentation in blocks and such weren't happening and these couple of queries seem sufficient for the handful of things I tested in the editor.